### PR TITLE
Handle invalid Unicode in metadata values.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -695,7 +695,7 @@ class TestYara(unittest.TestCase):
     def testMeta(self):
 
         r = yara.compile(source=r'rule test { meta: a = "\x80" condition: true }')
-        self.assertTrue(list(r)[0].meta['a'] == b'\x80')
+        self.assertTrue(list(r)[0].meta['a'] == '' or list(r)[0].meta['a'] == r'\x80')
 
     # This test is similar to testMeta but it tests the meta data generated
     # when a Match object is created.
@@ -703,7 +703,7 @@ class TestYara(unittest.TestCase):
 
         r = yara.compile(source=r'rule test { meta: a = "\x80" condition: true }')
         m = r.match(data='dummy')
-        self.assertTrue(list(m)[0].meta['a'] == b'\x80')
+        self.assertTrue(list(m)[0].meta['a'] == '' or list(r)[0].meta['a'] == r'\x80')
 
     def testFilesize(self):
 

--- a/yara-python.c
+++ b/yara-python.c
@@ -46,7 +46,7 @@ typedef long Py_hash_t;
 #endif
 
 #if PY_MAJOR_VERSION >= 3
-#define PY_STRING(x) PyUnicode_FromString(x)
+#define PY_STRING(x) PyUnicode_DecodeUTF8(x, strlen(x), "ignore" )
 #define PY_STRING_TO_C(x) PyUnicode_AsUTF8(x)
 #define PY_STRING_CHECK(x) PyUnicode_Check(x)
 #else
@@ -717,22 +717,10 @@ int yara_callback(
     else if (meta->type == META_TYPE_BOOLEAN)
       object = PyBool_FromLong((long) meta->integer);
     else
-    {
       object = PY_STRING(meta->string);
-      if (object == NULL)
-      {
-        // The PY_STRING() call failed, likely because the metadata value is not
-        // valid unicode, so let's clear the error and treat it as bytes.
-        PyErr_Clear();
-        object = PyBytes_FromString(meta->string);
-      }
-    }
 
-    if (object != NULL)
-    {
-      PyDict_SetItemString(meta_list, meta->identifier, object);
-      Py_DECREF(object);
-    }
+    PyDict_SetItemString(meta_list, meta->identifier, object);
+    Py_DECREF(object);
   }
 
   yr_rule_strings_foreach(rule, string)
@@ -1332,17 +1320,10 @@ static PyObject* Rules_next(
       else if (meta->type == META_TYPE_BOOLEAN)
         object = PyBool_FromLong((long) meta->integer);
       else
-      {
         object = PY_STRING(meta->string);
-        if (object == NULL)
-          object = PyBytes_FromString(meta->string);
-      }
 
-      if (object != NULL)
-      {
-        PyDict_SetItemString(meta_list, meta->identifier, object);
-        Py_DECREF(object);
-      }
+      PyDict_SetItemString(meta_list, meta->identifier, object);
+      Py_DECREF(object);
     }
 
     rule->identifier = PY_STRING(rules->iter_current_rule->identifier);


### PR DESCRIPTION
Defines PY_STRING to convert bytes as UTF8 to Unicode with 'ignore' decode error handling. For tests, accepts metadata output with stripped invalid characters, or the original unescaped characters if YARA changes behavior to not unescape metadata strings.